### PR TITLE
Create nfcSupportCheckreq.json

### DIFF
--- a/ec-headless-sample/nfc/nfcSupportCheckreq.json
+++ b/ec-headless-sample/nfc/nfcSupportCheckreq.json
@@ -1,0 +1,9 @@
+{
+  "service": "in.juspay.hyperapi",
+  "requestId": "88284034-1dab-45ab-8897-9013bd3914ac",
+  "payload": 
+  {
+    "action": "nfcSupportCheck"
+  },
+  "client_id": "clientID"
+}


### PR DESCRIPTION
Create nfcSupportCheckreq.json in a new folder. This is for the NFC. Creating under headless as its only for SDK merchant.