### PR TITLE
Update apay.podfile

### DIFF
--- a/APB/apay.podfile
+++ b/APB/apay.podfile
@@ -1,4 +1,1 @@
-pod 'HyperAPay', '2.1.41'
-
-//The HyperAPay version is tied to the version of your iOS Hyper SDK.// 
-//If you're using the latest SDK version (2.1.41), the corresponding HyperAPay version should also be 2.1.41.//
+pod 'HyperAPay', '2.2.2'


### PR DESCRIPTION
Updating the version and removing the text for 'HyperAPay version being tied to the version of iOS Hyper SDK'