### PR TITLE
Fix onBackPressed handling to respect hyperServicesHolder response

### DIFF
--- a/payment-page-android/payment-page-android-java-integration-demo/app/src/main/java/in/juspay/devtools/CheckoutActivity.java
+++ b/payment-page-android/payment-page-android-java-integration-demo/app/src/main/java/in/juspay/devtools/CheckoutActivity.java
@@ -238,12 +238,11 @@ public class CheckoutActivity extends AppCompatActivity {
     //block:start:onBackPressed
     @Override
     public void onBackPressed() {
-        boolean handleBackpress = hyperServicesHolder.handleBackPress();
-        if(handleBackpress) {
-            super.onBackPressed();
-        }
-
-    }
+    boolean handled = hyperServicesHolder.handleBackPress();
+      if (!handled) { // only call super if not handled
+        super.onBackPressed();
+       }
+   }
     //block:end:onBackPressed
 
     private void updatingUI(){


### PR DESCRIPTION
Currently, the onBackPressed method calls super.onBackPressed() even when 
hyperServicesHolder.handleBackPress() has already handled the back press. 
This can lead to unintended navigation and inconsistent behavior.

This PR updates the logic to only call super.onBackPressed() when 
handleBackPress() returns false, ensuring that back presses are properly 
intercepted when needed. The method structure and naming are preserved to 
align with existing code standards and CI/CD checks.
